### PR TITLE
Docker rename support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,16 @@ go:
 env:
 - TEST_ENV=true TEST_ENV2=false
 - TEST_ENV=false TEST_ENV2=true
+before_cache:
+- rm -rf $GOPATH/src/github.com/docker
+- rm -rf $GOPATH/src/github.com/jkawamoto
+- rm -rf $GOPATH/src/github.com/jteeuwen
+
+cache:
+  directories:
+    - $GOPATH/src
+    - $GOPATH/pkg
+
 install:
 - make get-deps
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - $GOPATH/pkg
 
 install:
-- make get-deps
+- make -d get-deps
 script:
 - echo $TEST_ENV
 - if [[ $TEST_ENV = true ]]; then make test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ cache:
     - $GOPATH/pkg
 
 install:
-- rm -rf $GOPATH/src/github.com/docker
-- rm -rf $GOPATH/src/github.com/jkawamoto
-- rm -rf $GOPATH/src/github.com/jteeuwen
 - make get-deps
 script:
 - echo $TEST_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ cache:
     - $GOPATH/pkg
 
 install:
+- rm -rf $GOPATH/src/github.com/docker
+- rm -rf $GOPATH/src/github.com/jkawamoto
+- rm -rf $GOPATH/src/github.com/jteeuwen
 - make get-deps
 script:
 - echo $TEST_ENV

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -75,7 +75,7 @@ This software uses the following open source libraries:
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
-## [docker](https://github.com/docker/docker)
+## [docker](https://github.com/moby/moby)
 
 > Copyright 2013-2016 Docker, Inc.
 >

--- a/command/docker.go
+++ b/command/docker.go
@@ -24,10 +24,10 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	client "github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/moby/moby/api/types"
+	"github.com/moby/moby/api/types/container"
+	client "github.com/moby/moby/client"
+	"github.com/moby/moby/pkg/stdcopy"
 )
 
 // DockerfileAsset defines a asset name for Dockerfile.

--- a/docs/content/info/LICENSES.md
+++ b/docs/content/info/LICENSES.md
@@ -81,7 +81,7 @@ This software uses the following open source libraries:
 > OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 > SOFTWARE.
 
-### [docker](https://github.com/docker/docker)
+### [docker](https://github.com/moby/moby)
 
 > Copyright 2013-2016 Docker, Inc.
 >


### PR DESCRIPTION
Change from Docker to moby

- Error log
```
% go get -d -v github.com/jkawamoto/loci
github.com/jkawamoto/loci (download)
github.com/docker/docker (download)
package github.com/docker/docker/pkg/stdcopy: cannot find package "github.com/docker/docker/pkg/stdcopy" in any of:
        /usr/local/opt/go/libexec/src/github.com/docker/docker/pkg/stdcopy (from $GOROOT)
        ${GOPATH}/src/github.com/docker/docker/pkg/stdcopy (from $GOPATH)
```